### PR TITLE
Add more "slim" aliases (especially "stretch-YYYYMMDD-slim", etc)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -127,18 +127,20 @@ for version in "${suites[@]}"; do
 		done
 		[ "${#variantArches[@]}" -gt 0 ] || continue
 
-		variantAliases=( "$version-$variant" )
+		variantAliases=()
 		case "$variant" in
 			slim)
 				for versionAlias in "${versionAliases[@]}"; do
 					case "$versionAlias" in
-						"$version"*) ;; # "stretch", "stretch-YYYYMMDD", etc
 						latest) ;;
 						*)
 							variantAliases+=( "$versionAlias-$variant" )
 							;;
 					esac
 				done
+				;;
+			*)
+				variantAliases+=( "$version-$variant" )
 				;;
 		esac
 


### PR DESCRIPTION
This is along a similar line to https://github.com/debuerreotype/docker-debian-artifacts/commit/c793937632f8bcc6712a14535c37b870c2f63374 / https://github.com/debuerreotype/docker-debian-artifacts/issues/22.

```diff
$ diff -u <(bashbrew cat debian) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2018-09-27 11:05:37.571090746 -0700
+++ /dev/fd/62	2018-09-27 11:05:37.571090746 -0700
@@ -1,6 +1,6 @@
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Paul Tagliamonte <paultag@debian.org> (@paultag)
 GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
-GitCommit: c793937632f8bcc6712a14535c37b870c2f63374
+GitCommit: ed3be2ac987cd819ba03f8b6f58abae85db7a0a5
 amd64-GitCommit: ed15c6a0b511d2985ca252f59f4318b1fe2a7a59
 amd64-GitFetch: refs/heads/dist-amd64
 arm32v5-GitCommit: 61e1228b9984053462f805945d3f1912bc0b612f
@@ -20,7 +20,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster
 
-Tags: buster-slim
+Tags: buster-slim, buster-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: buster/slim
 
@@ -36,7 +36,7 @@
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie/backports
 
-Tags: jessie-slim, 8.11-slim, 8-slim
+Tags: jessie-slim, jessie-20180831-slim, 8.11-slim, 8-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: jessie/slim
 
@@ -48,7 +48,7 @@
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable/backports
 
-Tags: oldoldstable-slim
+Tags: oldoldstable-slim, oldoldstable-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldoldstable/slim
 
@@ -60,7 +60,7 @@
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable/backports
 
-Tags: oldstable-slim
+Tags: oldstable-slim, oldstable-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: oldstable/slim
 
@@ -72,7 +72,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid
 
-Tags: sid-slim
+Tags: sid-slim, sid-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: sid/slim
 
@@ -84,7 +84,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/backports
 
-Tags: stable-slim
+Tags: stable-slim, stable-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/slim
 
@@ -96,7 +96,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/backports
 
-Tags: stretch-slim, 9.5-slim, 9-slim
+Tags: stretch-slim, stretch-20180831-slim, 9.5-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stretch/slim
 
@@ -104,7 +104,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing
 
-Tags: testing-slim
+Tags: testing-slim, testing-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: testing/slim
 
@@ -112,7 +112,7 @@
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable
 
-Tags: unstable-slim
+Tags: unstable-slim, unstable-20180831-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: unstable/slim
 
@@ -124,6 +124,6 @@
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy/backports
 
-Tags: wheezy-slim, 7.11-slim, 7-slim
+Tags: wheezy-slim, wheezy-20180831-slim, 7.11-slim, 7-slim
 Architectures: amd64, arm32v5, arm32v7, i386
 Directory: wheezy/slim
```