### PR TITLE
Add an explicit "Update Frequency" note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # docker-debian-artifacts
 
 Official builds of [debuerreotype](https://github.com/debuerreotype/debuerreotype)-generated [Debian](https://www.debian.org/) tarballs for [use in Docker](https://github.com/docker-library/official-images/blob/master/library/debian).
+
+## Update Frequency
+
+We strive to publish updated builds at least once a month (~30 days), but will also rebuild earlier if there is a major or minor Debian release *or* if there is a severe security issue that warrants doing so.
+
+(We try to avoid publishing *too* frequently, because the downstream rebuild effect every time we do is absolutely immense.)


### PR DESCRIPTION
This brings in the content from https://github.com/docker-library/faq#why-does-my-security-scanner-show-that-an-image-has-cves to this repository, where it frankly belongs (and that could be updated to link to this).

Closes #133